### PR TITLE
Fixed repeatable missions rewards

### DIFF
--- a/dDatabase/Tables/CDMissionsTable.cpp
+++ b/dDatabase/Tables/CDMissionsTable.cpp
@@ -58,7 +58,7 @@ CDMissionsTable::CDMissionsTable(void) {
         entry.reward_item2_repeatable = tableData.getIntField(32, -1);
         entry.reward_item2_repeat_count = tableData.getIntField(33, -1);
         entry.reward_item3_repeatable = tableData.getIntField(34, -1);
-        entry.reward_item3_repeat_count = tableData.getIntField(34, -1);
+        entry.reward_item3_repeat_count = tableData.getIntField(35, -1);
         entry.reward_item4_repeatable = tableData.getIntField(36, -1);
         entry.reward_item4_repeat_count = tableData.getIntField(37, -1);
         entry.time_limit = tableData.getIntField(38, -1);

--- a/dGame/dMission/Mission.cpp
+++ b/dGame/dMission/Mission.cpp
@@ -438,10 +438,13 @@ void Mission::YieldRewards() {
         items.emplace_back(info->reward_item4_repeatable, info->reward_item4_repeat_count);
 
         for (const auto& pair : items) {
-            if (pair.second <= 0 || (m_Reward > 0 && pair.first != m_Reward)) {
+            // Some missions reward zero of an item and so they must be allowed through this clause,
+            // hence pair.second < 0 instead of pair.second <= 0.
+            if (pair.second < 0 || (m_Reward > 0 && pair.first != m_Reward)) {
                 continue;
             }
 
+            // If a mission rewards zero of an item, make it reward 1.
             auto count = pair.second > 0 ? pair.second : 1;
 
             // Sanity check, 6 is the max any mission yields
@@ -467,10 +470,13 @@ void Mission::YieldRewards() {
     items.emplace_back(info->reward_item4, info->reward_item4_count);
 
     for (const auto& pair : items) {
+        // Some missions reward zero of an item and so they must be allowed through this clause,
+        // hence pair.second < 0 instead of pair.second <= 0.
         if (pair.second < 0 || (m_Reward > 0 && pair.first != m_Reward)) {
             continue;
         }
-
+        
+        // If a mission rewards zero of an item, make it reward 1.
         auto count = pair.second > 0 ? pair.second : 1;
 
         // Sanity check, 6 is the max any mission yields

--- a/dScripts/NpcWispServer.cpp
+++ b/dScripts/NpcWispServer.cpp
@@ -14,15 +14,15 @@ void NpcWispServer::OnMissionDialogueOK(Entity* self, Entity* target, int missio
 	if (inventory == nullptr)
 	    return;
 
-	LOT maelstromCubeLot = 14592;
-	auto* maelstromCube = inventory->FindItemByLot(maelstromCubeLot);
+	LOT maelstromVacuumLot = 14592;
+	auto* maelstromVacuum = inventory->FindItemByLot(maelstromVacuumLot);
 
-	// For the daily we add the maelstrom cube if the player doesn't have it yet
+	// For the daily we add the maelstrom vacuum if the player doesn't have it yet
 	if (missionID == 1883 && (missionState == MissionState::MISSION_STATE_AVAILABLE || missionState == MissionState::MISSION_STATE_COMPLETE_AVAILABLE)
-	&& maelstromCube == nullptr) {
-	    inventory->AddItem(maelstromCubeLot, 1);
+	&& maelstromVacuum == nullptr) {
+	    inventory->AddItem(maelstromVacuumLot, 1);
 	} else if (missionState == MissionState::MISSION_STATE_READY_TO_COMPLETE || missionState == MissionState::MISSION_STATE_COMPLETE_READY_TO_COMPLETE) {
-	    inventory->RemoveItem(maelstromCubeLot, 1);
+	    inventory->RemoveItem(maelstromVacuumLot, 1);
 	}
 
 	// Next up hide or show the samples based on the mission state


### PR DESCRIPTION
Fixed a bug where the third mission reward item was set incorrectly and also fixed an off by one error for the daily mission rewards that prevented players from claiming rewards of 0 items.